### PR TITLE
Minor rcp2mid fixes

### DIFF
--- a/YamahaDemoSongDump.c
+++ b/YamahaDemoSongDump.c
@@ -1,6 +1,6 @@
 // Yamaha TG/MU Demo Song Dumper
 // -----------------------------
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cotton2mid.c
+++ b/cotton2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 

--- a/eash2mid.c
+++ b/eash2mid.c
@@ -13,7 +13,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/fmp2mid.c
+++ b/fmp2mid.c
@@ -52,7 +52,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/gems2mid.c
+++ b/gems2mid.c
@@ -11,7 +11,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 #ifndef INLINE

--- a/gmd2mid.c
+++ b/gmd2mid.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/grc2mid.c
+++ b/grc2mid.c
@@ -13,7 +13,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 

--- a/ims2mid.c
+++ b/ims2mid.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <stdtype.h>
+#include "stdtype.h"
 
 #define INLINE	static __inline
 

--- a/konami2mid.c
+++ b/konami2mid.c
@@ -8,7 +8,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 

--- a/mdc2mid.c
+++ b/mdc2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/midi_utils.h
+++ b/midi_utils.h
@@ -44,7 +44,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifdef RUNNING_NOTES
 

--- a/mmd2mid.c
+++ b/mmd2mid.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/mmu2mid.c
+++ b/mmu2mid.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/nwc12mid.c
+++ b/nwc12mid.c
@@ -43,7 +43,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/pmd2mid.c
+++ b/pmd2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/rcp2mid.c
+++ b/rcp2mid.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/rcp2mid.c
+++ b/rcp2mid.c
@@ -1150,7 +1150,7 @@ static UINT8 RcpTrk2MidTrk(UINT32 rcpLen, const UINT8* rcpData, const RCP_INFO* 
 				UINT32 tempoVal;
 				
 				if (cmdP2 != 0)
-					printf("Warning Track %u: Gradual Tempo Change (speed 0x40) at 0x%04X!\n", trkID, cmdP2, prevPos);
+					printf("Warning Track %u: Gradual Tempo Change (speed 0x40, cmdP2 %u) at 0x%04X!\n", trkID, cmdP2, prevPos);
 				tempoVal = Tempo2Mid(rcpInf->tempoBPM, cmdP1);
 				WriteBE32(tempArr, tempoVal);
 				WriteMetaEvent(fInf, MTS, 0x51, 0x03, &tempArr[0x01]);

--- a/srmp4-midi.c
+++ b/srmp4-midi.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/syx2mid.c
+++ b/syx2mid.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/top2mid.c
+++ b/top2mid.c
@@ -8,7 +8,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 #ifdef _MSC_VER

--- a/top2mid_Arc.c
+++ b/top2mid_Arc.c
@@ -8,7 +8,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 #ifdef _MSC_VER

--- a/wtmd2mid.c
+++ b/wtmd2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 #include <stdbool.h>
 
 void ConvertAllSongs(UINT16 MusBankList);

--- a/wtmf2mid.c
+++ b/wtmf2mid.c
@@ -10,7 +10,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/yong2mid.c
+++ b/yong2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)

--- a/zmd2mid.c
+++ b/zmd2mid.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <math.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 #ifndef INLINE
 #if defined(_MSC_VER)


### PR DESCRIPTION
Thanks for writing these! This PR has a couple minor fixes for things I ran into while building.

* My compiler complained about not being able to find `stdtype.h`, since it's not a system header. I changed all references to it to use quotes instead of brackets.
* It looks like a `printf` in `rcp2mid` missed adding a new parameter when a new argument got added in 8fb515840f400694596d766d30755b0d8d197f4d.