### PR TITLE
Update YamahaDemoSongDump.c

### DIFF
--- a/YamahaDemoSongDump.c
+++ b/YamahaDemoSongDump.c
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
 	free(srcData);	srcData = NULL;
 	free(dstData);	dstData = NULL;
 	
-	return;
+	return 0;
 }
 
 static UINT16 DetectTrackCount(UINT32 ptrListOfs)


### PR DESCRIPTION
fix compiler error: 
YamahaDemoSongDump.c:140:2: error: non-void function 'main' should return a
      value [-Wreturn-type]
        return;
        ^
1 error generated.