### PR TITLE
Update M2MidiDec.c

### DIFF
--- a/M2MidiDec.c
+++ b/M2MidiDec.c
@@ -261,7 +261,7 @@ int main(int argc, char* argv[])
 			return 2;
 		}
 		
-		LoadROMsMerged(argc - (argbase + 2), &argv[argbase + 2], &SmpROM.Size, &SmpROM.Data);
+		LoadROMsMerged(argc - (argbase + 2), (const char**)&argv[argbase + 2], &SmpROM.Size, &SmpROM.Data);
 	}
 	
 	if (ReadBE16(&ROMData[0x04]) == 0x6000)


### PR DESCRIPTION
fix compilation error:
```
M2MidiDec.c: In function 'int main(int, char**)':
M2MidiDec.c:264:54: error: invalid conversion from 'char**' to 'const char**' [-
fpermissive]
  264 |                 LoadROMsMerged(argc - (argbase + 2), &argv[argbase + 2],
 &SmpROM.Size, &SmpROM.Data);
      |                                                      ^~~~~~~~~~~~~~~~~~
      |                                                      |
      |                                                      char**
M2MidiDec.c:43:59: note:   initializing argument 2 of 'UINT8 LoadROMsMerged(size
_t, const char**, UINT32*, UINT8**)'
   43 | static UINT8 LoadROMsMerged(size_t romCount, const char** fileNames, UIN
T32* retSize, UINT8** retData);
      |                                              ~~~~~~~~~~~~~^~~~~~~~~
```